### PR TITLE
Potential fix for code scanning alert no. 2: Unsafe expansion of self-closing HTML tag

### DIFF
--- a/vendor/jquery/jquery.slim.js
+++ b/vendor/jquery/jquery.slim.js
@@ -5976,7 +5976,7 @@ function remove( elem, selector, keepData ) {
 
 jQuery.extend( {
 	htmlPrefilter: function( html ) {
-		return html.replace( rxhtmlTag, "<$1></$2>" );
+		return html;
 	},
 
 	clone: function( elem, dataAndEvents, deepDataAndEvents ) {


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/2](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/2)

The safest fix is to stop performing regex-based self-closing tag expansion in `htmlPrefilter`.  
In this file, the best minimal-risk change is:

- Keep `htmlPrefilter` API intact.
- Return the input HTML unchanged instead of applying `rxhtmlTag` replacement.

This avoids rewriting sanitized input into potentially unsafe HTML while preserving function signatures and call sites.  
Concretely, edit `vendor/jquery/jquery.slim.js` at the `jQuery.extend({ htmlPrefilter: ... })` section around lines 5978–5980.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
