### PR TITLE
Potential fix for code scanning alert no. 32: Unsafe HTML constructed from library input

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -293,7 +293,15 @@
       },
       directionNav: {
         setup: function() {
-          var directionNavScaffold = $('<ul class="' + namespace + 'direction-nav"><li><a class="' + namespace + 'prev" href="#">' + slider.vars.prevText + '</a></li><li><a class="' + namespace + 'next" href="#">' + slider.vars.nextText + '</a></li></ul>');
+          var directionNavScaffold = $('<ul>').addClass(namespace + 'direction-nav'),
+              prevItem = $('<li>'),
+              nextItem = $('<li>'),
+              prevLink = $('<a>').addClass(namespace + 'prev').attr('href', '#').text(slider.vars.prevText),
+              nextLink = $('<a>').addClass(namespace + 'next').attr('href', '#').text(slider.vars.nextText);
+
+          prevItem.append(prevLink);
+          nextItem.append(nextLink);
+          directionNavScaffold.append(prevItem).append(nextItem);
 
           // CONTROLSCONTAINER:
           if (slider.controlsContainer) {


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/32](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/32)

Use safe DOM/text APIs instead of HTML string concatenation for `prevText`/`nextText`.

Best fix in this snippet:
- In `assets/flexslider/jquery.flexslider.js`, inside `methods.directionNav.setup` (around line 296), replace the single HTML-concatenated scaffold creation with element creation and `.text(...)` assignment for user-configurable labels.
- Keep class names, structure, and behavior unchanged (`ul > li > a`, same `namespace` classes and `href="#"`), only change how link text is assigned.
- No new dependency is needed; jQuery already provides safe text insertion.

This preserves functionality (same visible labels, same selectors/events) while eliminating XSS through `prevText`/`nextText`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
