### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/vendor/bootstrap/js/bootstrap.bundle.js
+++ b/vendor/bootstrap/js/bootstrap.bundle.js
@@ -1073,7 +1073,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/9](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/9)

To fix this safely, avoid giving untrusted text directly to jQuery’s `$()` constructor. Instead, resolve the selector using `document.querySelector` (or `querySelectorAll`) and pass the resulting DOM element to jQuery. This ensures the value is interpreted only as a CSS selector, never as HTML.

Best single change (no functionality change) is in `vendor/bootstrap/js/bootstrap.bundle.js` at line 1076 region in `Carousel._dataApiClickHandler`:
- Replace `var target = $(selector)[0];`
- With `var target = document.querySelector(selector);`

Why this is best:
- It preserves behavior (select first matching element).
- It matches the existing validation strategy in `Util.getSelectorFromElement`.
- No new imports/dependencies required.
- Eliminates the risky `$()` string interpretation sink.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
