### PR TITLE
Potential fix for code scanning alert no. 26: Unsafe HTML constructed from library input

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -11,7 +11,7 @@
     // making variables public
     slider.vars = $.extend({}, $.flexslider.defaults, options);
 
-    var namespace = slider.vars.namespace,
+    var namespace = (slider.vars.namespace || "").replace(/[^A-Za-z0-9_-]/g, ""),
         msGesture = window.navigator && window.navigator.msPointerEnabled && window.MSGesture,
         touch = (( "ontouchstart" in window ) || msGesture || window.DocumentTouch && document instanceof DocumentTouch) && slider.vars.touch,
         // depricating this idea, as devices are being released with both of these events
@@ -20,6 +20,14 @@
         watchedEvent = "",
         watchedEventClearTimer,
         vertical = slider.vars.direction === "vertical",
+        reverse = slider.vars.reverse,
+        carousel = (slider.vars.itemWidth > 0),
+        fade = slider.vars.animation === "fade",
+        asNav = slider.vars.asNavFor !== "",
+        methods = {},
+        focused = true;
+
+    if (namespace === "") { namespace = "flex-"; }
         reverse = slider.vars.reverse,
         carousel = (slider.vars.itemWidth > 0),
         fade = slider.vars.animation === "fade",


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/26](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/26)

Best fix: stop building HTML with raw concatenated `namespace`; instead sanitize `namespace` to safe class-token characters before using it in HTML/class attributes. This preserves behavior (class prefixing) while blocking attribute/HTML injection.

In `assets/flexslider/jquery.flexslider.js`, inside `$.flexslider = function(el, options)`, replace the current `namespace` assignment with a sanitized version derived from `slider.vars.namespace`. Allow only characters valid for class-like prefixes (`[A-Za-z0-9_-]`), and default to `"flex-"` if result is empty. This single change protects line 209 and other places that reuse `namespace` in generated markup/classes, without changing plugin API shape or requiring new dependencies.

No new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
