### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/vendor/bootstrap/js/bootstrap.js
+++ b/vendor/bootstrap/js/bootstrap.js
@@ -1074,7 +1074,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/8](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/8)

To fix this class of issue, avoid using jQuery’s `$()` constructor with untrusted strings. Instead, resolve the selector through a DOM API (`document.querySelector`) and then wrap the resulting element with jQuery if needed. This ensures the input is interpreted only as a CSS selector, never as HTML.

Best targeted fix here:
- File: `vendor/bootstrap/js/bootstrap.js`
- Region: `Carousel._dataApiClickHandler`, around line 1077.
- Replace `var target = $(selector)[0];` with `var target = document.querySelector(selector);`.

This keeps existing behavior (getting the first matched element), works with existing downstream code (`$(target)` calls still valid), and removes the risky string-to-`$()` conversion. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
