### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -211,7 +211,6 @@
         setupPaging: function() {
           var type = (slider.vars.controlNav === "thumbnails") ? 'control-thumbs' : 'control-paging',
               j = 1,
-              item,
               slide;
 
           slider.controlNavScaffold = $('<ol class="'+ namespace + 'control-nav ' + namespace + type + '"></ol>');

--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -224,11 +224,16 @@
                 var thumbSrc = slide.attr('data-thumb') || '',
                     safeThumbSrc = '';
 
-                // Accept only http(s), protocol-relative, and relative URLs.
-                // Prevent interpreting attacker-controlled DOM text as executable content.
-                if (/^(https?:\/\/|\/\/|\/|\.\/|\.\.\/|[^:]+$)/i.test(thumbSrc) && !/^\s*(javascript|data):/i.test(thumbSrc)) {
-                  safeThumbSrc = thumbSrc;
-                }
+                // Only allow http(s) URLs and same-origin relative URLs.
+                // Parse via URL API to avoid interpreting attacker-controlled text as executable content.
+                try {
+                  var parsedThumbUrl = new URL(thumbSrc, window.location.href);
+                  var isHttp = parsedThumbUrl.protocol === 'http:' || parsedThumbUrl.protocol === 'https:';
+                  var isRelative = !/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(thumbSrc) && thumbSrc.indexOf('//') !== 0;
+                  if (isHttp && (isRelative || parsedThumbUrl.origin === window.location.origin)) {
+                    safeThumbSrc = parsedThumbUrl.href;
+                  }
+                } catch (e) {}
 
                 $li.append($('<img />').attr('src', safeThumbSrc));
               } else {

--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -221,7 +221,16 @@
               slide = slider.slides.eq(i);
               var $li = $('<li></li>');
               if (slider.vars.controlNav === "thumbnails") {
-                $li.append($('<img />').attr('src', slide.attr('data-thumb')));
+                var thumbSrc = slide.attr('data-thumb') || '',
+                    safeThumbSrc = '';
+
+                // Accept only http(s), protocol-relative, and relative URLs.
+                // Prevent interpreting attacker-controlled DOM text as executable content.
+                if (/^(https?:\/\/|\/\/|\/|\.\/|\.\.\/|[^:]+$)/i.test(thumbSrc) && !/^\s*(javascript|data):/i.test(thumbSrc)) {
+                  safeThumbSrc = thumbSrc;
+                }
+
+                $li.append($('<img />').attr('src', safeThumbSrc));
               } else {
                 $li.append($('<a></a>').text(j));
               }

--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -219,12 +219,19 @@
           if (slider.pagingCount > 1) {
             for (var i = 0; i < slider.pagingCount; i++) {
               slide = slider.slides.eq(i);
-              item = (slider.vars.controlNav === "thumbnails") ? '<img src="' + slide.attr( 'data-thumb' ) + '"/>' : '<a>' + j + '</a>';
+              var $li = $('<li></li>');
+              if (slider.vars.controlNav === "thumbnails") {
+                $li.append($('<img />').attr('src', slide.attr('data-thumb')));
+              } else {
+                $li.append($('<a></a>').text(j));
+              }
               if ( 'thumbnails' === slider.vars.controlNav && true === slider.vars.thumbCaptions ) {
                 var captn = slide.attr( 'data-thumbcaption' );
-                if ( '' != captn && undefined != captn ) item += '<span class="' + namespace + 'caption">' + captn + '</span>';
+                if ( '' != captn && undefined != captn ) {
+                  $li.append($('<span></span>').addClass(namespace + 'caption').text(captn));
+                }
               }
-              slider.controlNavScaffold.append('<li>' + item + '</li>');
+              slider.controlNavScaffold.append($li);
               j++;
             }
           }


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/7](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/7)

The best fix is to stop constructing HTML with string concatenation using tainted values, and instead build DOM nodes with jQuery/DOM APIs and set text/attributes through dedicated setters.

In `assets/flexslider/jquery.flexslider.js`, inside `controlNav.setupPaging` (around lines 220–228), replace the `item` string construction and `append('<li>' + item + '</li>')` with safe element creation:

- Create a `<li>` element via ` $('<li></li>')`.
- For thumbnails, create `<img />` and set `src` via `.attr('src', ...)`.
- For paging numbers, create `<a></a>` and set label via `.text(...)`.
- For captions, create `<span>` with class and set caption via `.text(captn)`.
- Append created nodes into `<li>`, then append `<li>` to `slider.controlNavScaffold`.

This preserves functionality while eliminating HTML parsing of untrusted strings. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
