### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/assets/textrotator/jquery.simple-text-rotator.js
+++ b/assets/textrotator/jquery.simple-text-rotator.js
@@ -112,8 +112,8 @@
             if (index + 1 == array.length) index = -1;
 
             el.html("");
-            $("<span class='front'>" + initial + "</span>").appendTo(el);
-            $("<span class='back'>" + array[index + 1] + "</span>").appendTo(
+            $("<span>", { "class": "front" }).text(initial).appendTo(el);
+            $("<span>", { "class": "back" }).text(array[index + 1]).appendTo(
               el
             );
             el.wrapInner("<span class='rotating' />")
@@ -140,8 +140,8 @@
             if (index + 1 == array.length) index = -1;
 
             el.html("");
-            $("<span class='front'>" + initial + "</span>").appendTo(el);
-            $("<span class='back'>" + array[index + 1] + "</span>").appendTo(
+            $("<span>", { "class": "front" }).text(initial).appendTo(el);
+            $("<span>", { "class": "back" }).text(array[index + 1]).appendTo(
               el
             );
             el.wrapInner("<span class='rotating' />")


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/6](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/6)

Use DOM-safe element construction instead of HTML string concatenation where `initial` and `array[index + 1]` are inserted.

Best fix in this file:
- In `assets/textrotator/jquery.simple-text-rotator.js`, in both `flipCube` and `flipCubeUp` branches, replace:
  - ` $("<span class='front'>" + initial + "</span>").appendTo(el);`
  - ` $("<span class='back'>" + array[index + 1] + "</span>").appendTo(el);`
- With safe construction:
  - ` $("<span>", { "class": "front" }).text(initial).appendTo(el);`
  - ` $("<span>", { "class": "back" }).text(array[index + 1]).appendTo(el);`

This preserves behavior (same classes, same displayed text, same animation flow) while preventing text from being interpreted as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
