### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/assets/textrotator/jquery.simple-text-rotator.js
+++ b/assets/textrotator/jquery.simple-text-rotator.js
@@ -84,10 +84,10 @@
             if (index + 1 == array.length) index = -1;
 
             el.html("");
-            $("<span class='front'>" + initial + "</span>").appendTo(el);
-            $("<span class='back'>" + array[index + 1] + "</span>").appendTo(
-              el
-            );
+            $("<span class='front'></span>").text(initial).appendTo(el);
+            $("<span class='back'></span>")
+              .text(array[index + 1])
+              .appendTo(el);
             el.wrapInner("<span class='rotating' />")
               .find(".rotating")
               .hide()
@@ -112,10 +112,10 @@
             if (index + 1 == array.length) index = -1;
 
             el.html("");
-            $("<span class='front'>" + initial + "</span>").appendTo(el);
-            $("<span class='back'>" + array[index + 1] + "</span>").appendTo(
-              el
-            );
+            $("<span class='front'></span>").text(initial).appendTo(el);
+            $("<span class='back'></span>")
+              .text(array[index + 1])
+              .appendTo(el);
             el.wrapInner("<span class='rotating' />")
               .find(".rotating")
               .hide()


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/5](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/5)

The correct fix is to stop embedding `initial` (and other text values) inside HTML strings. Instead, create the `<span>` elements structurally and set their text using `.text(...)`, which safely escapes content and preserves existing functionality.

Best single approach in this file:
- In `assets/textrotator/jquery.simple-text-rotator.js`, replace:
  - ` $("<span class='front'>" + initial + "</span>").appendTo(el);`
  - ` $("<span class='back'>" + array[index + 1] + "</span>").appendTo(el);`
- With safe element creation:
  - ` $("<span class='front'></span>").text(initial).appendTo(el);`
  - ` $("<span class='back'></span>").text(array[index + 1]).appendTo(el);`
- Apply the same change in both shown flip branches (`flipUp` and `flipCube`) to eliminate equivalent vulnerable sinks there too.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
