### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe expansion of self-closing HTML tag

### DIFF
--- a/vendor/jquery/jquery.js
+++ b/vendor/jquery/jquery.js
@@ -5976,7 +5976,7 @@ function remove( elem, selector, keepData ) {
 
 jQuery.extend( {
 	htmlPrefilter: function( html ) {
-		return html.replace( rxhtmlTag, "<$1></$2>" );
+		return html;
 	},
 
 	clone: function( elem, dataAndEvents, deepDataAndEvents ) {


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/1](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/1)

The safest fix is to stop expanding self-closing tags in `htmlPrefilter`. In jQuery 3.5+, this was effectively changed to a no-op specifically to avoid this class of XSS issues. That preserves core behavior for modern HTML parsing while removing the dangerous regex rewrite.

Best single change (without introducing new dependencies or broad refactors):
- In `vendor/jquery/jquery.js`, update `jQuery.extend({ htmlPrefilter: ... })` so it returns `html` unchanged.
- Leave `rxhtmlTag` defined (to minimize unrelated edits and risk), but it will become unused.
- No new imports, methods, or package dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
