### PR TITLE
Potential fix for code scanning alert no. 23: Unsafe jQuery plugin

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -1047,7 +1047,7 @@
       slider.update(pos, "add");
 
       // update slider.slides
-      slider.slides = $(slider.vars.selector + ':not(.clone)', slider);
+      slider.slides = $($.find(slider.vars.selector + ':not(.clone)', slider));
       // re-setup the slider to accomdate new slide
       slider.setup();
 

--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -1047,7 +1047,7 @@
       slider.update(pos, "add");
 
       // update slider.slides
-      slider.slides = $($.find(slider.vars.selector + ':not(.clone)', slider));
+      slider.slides = $($.find(slider.vars.selector + ':not(.clone)', slider[0]));
       // re-setup the slider to accomdate new slide
       slider.setup();
 


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/23](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/23)

Safest fix without changing intended functionality: stop using `$()` for dynamic selector resolution where option data is involved, and use selector-only APIs (`jQuery.find`) so input is always interpreted as a CSS selector, not HTML. This aligns exactly with the secure pattern from the rule guidance.

In `assets/flexslider/jquery.flexslider.js`, update the slide refresh logic in `slider.addSlide` (line around 1050):
- Replace `slider.slides = $(slider.vars.selector + ':not(.clone)', slider);`
- With a selector-only query using `$.find(...)`, wrapped back into jQuery:
  - `slider.slides = $($.find(slider.vars.selector + ':not(.clone)', slider));`

No new imports or dependencies are needed. This keeps behavior (finding matching slide elements under `slider`) while removing unsafe plugin parsing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
