### PR TITLE
Potential fix for code scanning alert no. 24: Unsafe jQuery plugin

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -1073,7 +1073,7 @@
       slider.update(pos, "remove");
 
       // update slider.slides
-      slider.slides = $(slider.vars.selector + ':not(.clone)', slider);
+      slider.slides = slider.find(slider.vars.selector + ':not(.clone)');
       // re-setup the slider to accomdate new slide
       slider.setup();
 
@@ -1164,8 +1164,12 @@
     if (typeof options === "object") {
       return this.each(function() {
         var $this = $(this),
-            selector = (options.selector) ? options.selector : ".slides > li",
-            $slides = $this.find(selector);
+            selectorOption = (typeof options.selector === "string") ? $.trim(options.selector) : "",
+            selector = (selectorOption && selectorOption.charAt(0) !== "<") ? selectorOption : ".slides > li",
+            $slides;
+
+        options.selector = selector;
+        $slides = $this.find(selector);
 
       if ( ( $slides.length === 1 && options.allowOneSlide === true ) || $slides.length === 0 ) {
           $slides.fadeIn(400);


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/24](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/24)

General fix: never pass untrusted plugin option strings directly into `$()` in a way that could be interpreted as HTML. Validate option values intended to be selectors, and use selector APIs (`.find()` / `$.find`) that enforce selector semantics.

Best minimal fix in this file:
1. In `$.fn.flexslider`, sanitize `options.selector` before use:
   - Ensure it is a string.
   - Reject values that look like HTML (`<...>` start).
   - Fallback to safe default `".slides > li"` when invalid.
2. In `slider.removeSlide`, replace the unsafe `$()` selector construction with `slider.find(...)`, so the input is treated strictly as a selector scoped to `slider`.

Edits needed only in `assets/flexslider/jquery.flexslider.js`:
- Around line 1076: replace `$(slider.vars.selector + ':not(.clone)', slider)` with `slider.find(slider.vars.selector + ':not(.clone)')`.
- Around line 1167: compute a sanitized selector and use it for both `selector` and `options.selector`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
