### PR TITLE
Potential fix for code scanning alert no. 21: Unsafe jQuery plugin

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -1166,9 +1166,12 @@
         var $this = $(this),
             selectorOption = (typeof options.selector === "string") ? $.trim(options.selector) : "",
             selector = (selectorOption && selectorOption.charAt(0) !== "<") ? selectorOption : ".slides > li",
+            asNavForOption = (typeof options.asNavFor === "string") ? $.trim(options.asNavFor) : "",
+            asNavFor = (asNavForOption && asNavForOption.charAt(0) !== "<") ? asNavForOption : "",
             $slides;
 
         options.selector = selector;
+        options.asNavFor = asNavFor;
         $slides = $this.find(selector);
 
       if ( ( $slides.length === 1 && options.allowOneSlide === true ) || $slides.length === 0 ) {


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/21](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/21)

General fix: never pass potentially untrusted plugin options directly into `$(...)` when a CSS selector is intended. Normalize/validate the option first, and fall back safely if invalid. This matches how `options.selector` is already handled.

Best fix in this file: sanitize `asNavFor` once during plugin initialization (`$.fn.flexslider`) and then use that sanitized value throughout the plugin. Specifically:

- In `$.fn.flexslider` (around lines 1166–1172), add logic to trim and validate `options.asNavFor` as a selector string, rejecting values that start with `<` (HTML-like input). If invalid, set it to `""` (existing “disabled” behavior).
- Keep existing functionality: valid selector strings still work; invalid/HTML-like values disable nav sync instead of invoking jQuery HTML parsing.
- No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
