### PR TITLE
Potential fix for code scanning alert no. 19: Unsafe jQuery plugin

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -171,9 +171,12 @@
                 var posFromLeft = $slide.offset().left - $(slider).scrollLeft(); // Find position of slide relative to left of slider container
                 if( posFromLeft <= 0 && $slide.hasClass( namespace + 'active-slide' ) ) {
                   slider.flexAnimate(slider.getTarget("prev"), true);
-                } else if (!$(slider.vars.asNavFor).data('flexslider').animating && !$slide.hasClass(namespace + "active-slide")) {
-                  slider.direction = (slider.currentItem < target) ? "next" : "prev";
-                  slider.flexAnimate(target, slider.vars.pauseOnAction, false, true, true);
+                } else {
+                  var navTargetSlider = $($.find(slider.vars.asNavFor)).data('flexslider');
+                  if (navTargetSlider && !navTargetSlider.animating && !$slide.hasClass(namespace + "active-slide")) {
+                    slider.direction = (slider.currentItem < target) ? "next" : "prev";
+                    slider.flexAnimate(target, slider.vars.pauseOnAction, false, true, true);
+                  }
                 }
               });
           }else{
@@ -190,8 +193,9 @@
                   that.addEventListener("MSGestureTap", function (e){
                       e.preventDefault();
                       var $slide = $(this),
-                          target = $slide.index();
-                      if (!$(slider.vars.asNavFor).data('flexslider').animating && !$slide.hasClass('active')) {
+                          target = $slide.index(),
+                          navTargetSlider = $($.find(slider.vars.asNavFor)).data('flexslider');
+                      if (navTargetSlider && !navTargetSlider.animating && !$slide.hasClass('active')) {
                           slider.direction = (slider.currentItem < target) ? "next" : "prev";
                           slider.flexAnimate(target, slider.vars.pauseOnAction, false, true, true);
                       }


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/19](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/19)

General fix: avoid passing plugin option strings to `$(...)` where jQuery may treat them as HTML. For selector semantics, use `$.find(...)` (or equivalent strict selector handling) and then wrap results in jQuery if needed.

Best minimal fix in this file: replace the two `$(slider.vars.asNavFor)` usages in `asNav.setup` (lines around 174 and 194) with a safe selector resolution that never parses HTML:
- `var navTargetSlider = $($.find(slider.vars.asNavFor)).data('flexslider');`
- then check `navTargetSlider && !navTargetSlider.animating ...`

This preserves behavior (still resolves CSS selectors and reads `.data('flexslider')`) while removing HTML-construction risk and adding a null guard to avoid runtime errors when selector resolves to nothing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
