### PR TITLE
Potential fix for code scanning alert no. 17: Unsafe jQuery plugin

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -100,7 +100,7 @@
         if (slider.vars.directionNav) methods.directionNav.setup();
 
         // KEYBOARD:
-        if (slider.vars.keyboard && ($(slider.containerSelector).length === 1 || slider.vars.multipleKeyboard)) {
+        if (slider.vars.keyboard && ($.find(slider.containerSelector).length === 1 || slider.vars.multipleKeyboard)) {
           $(document).bind('keyup', function(event) {
             var keycode = event.keyCode;
             if (!slider.animating && (keycode === 39 || keycode === 37)) {


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/17](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/17)

The safest fix is to avoid passing plugin-controlled selector strings into `$()` where jQuery may interpret HTML. For the keyboard guard at line 103, replace `$(slider.containerSelector).length` with `$.find(slider.containerSelector).length`. `$.find` interprets input as a selector, not HTML construction, which removes the XSS vector while preserving behavior (we only need element-count existence check there).

Apply this change in **assets/flexslider/jquery.flexslider.js** in the `methods.init` keyboard section (around lines 102–104). No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
