### PR TITLE
Potential fix for code scanning alert no. 15: Unsafe jQuery plugin

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -1173,10 +1173,16 @@
             selector = (selectorOption && selectorOption.charAt(0) !== "<") ? selectorOption : ".slides > li",
             asNavForOption = (typeof options.asNavFor === "string") ? $.trim(options.asNavFor) : "",
             asNavFor = (asNavForOption && asNavForOption.charAt(0) !== "<") ? asNavForOption : "",
+            controlsContainerOption = (typeof options.controlsContainer === "string") ? $.trim(options.controlsContainer) : "",
+            controlsContainer = (controlsContainerOption && controlsContainerOption.charAt(0) !== "<") ? controlsContainerOption : "",
+            manualControlsOption = (typeof options.manualControls === "string") ? $.trim(options.manualControls) : "",
+            manualControls = (manualControlsOption && manualControlsOption.charAt(0) !== "<") ? manualControlsOption : "",
             $slides;
 
         options.selector = selector;
         options.asNavFor = asNavFor;
+        options.controlsContainer = controlsContainer;
+        options.manualControls = manualControls;
         $slides = $this.find(selector);
 
       if ( ( $slides.length === 1 && options.allowOneSlide === true ) || $slides.length === 0 ) {

--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -1173,16 +1173,16 @@
             selector = (selectorOption && selectorOption.charAt(0) !== "<") ? selectorOption : ".slides > li",
             asNavForOption = (typeof options.asNavFor === "string") ? $.trim(options.asNavFor) : "",
             asNavFor = (asNavForOption && asNavForOption.charAt(0) !== "<") ? asNavForOption : "",
-            controlsContainerOption = (typeof options.controlsContainer === "string") ? $.trim(options.controlsContainer) : "",
+            controlsContainerOption = (typeof options.controlsContainer === "string") ? $.trim(options.controlsContainer) : null,
             controlsContainer = (controlsContainerOption && controlsContainerOption.charAt(0) !== "<") ? controlsContainerOption : "",
-            manualControlsOption = (typeof options.manualControls === "string") ? $.trim(options.manualControls) : "",
+            manualControlsOption = (typeof options.manualControls === "string") ? $.trim(options.manualControls) : null,
             manualControls = (manualControlsOption && manualControlsOption.charAt(0) !== "<") ? manualControlsOption : "",
             $slides;
 
         options.selector = selector;
         options.asNavFor = asNavFor;
-        options.controlsContainer = controlsContainer;
-        options.manualControls = manualControls;
+        if (controlsContainerOption !== null) options.controlsContainer = controlsContainer;
+        if (manualControlsOption !== null) options.manualControls = manualControls;
         $slides = $this.find(selector);
 
       if ( ( $slides.length === 1 && options.allowOneSlide === true ) || $slides.length === 0 ) {


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/15](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/15)

The best fix is to sanitize plugin options that are later passed into jQuery selector construction so they cannot be interpreted as HTML strings. Keep behavior unchanged for valid selector strings, but reject/neutralize unsafe values (for example, those starting with `<`).

In `assets/flexslider/jquery.flexslider.js`, inside `$.fn.flexslider` (around lines 1171–1176), add normalization for `manualControls` and `controlsContainer` exactly like existing logic for `selector`/`asNavFor`: if option is a string, trim it; only keep it if non-empty and first char is not `<`; otherwise set to `""`. Then write these sanitized values back to `options` before constructing the slider instance. This ensures line 83 no longer receives HTML-capable input via `manualControls`, and line 81 is hardened too, without changing intended functionality for normal CSS selectors.

No new imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
