### PR TITLE
Potential fix for code scanning alert no. 15: Unsafe jQuery plugin

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -78,9 +78,15 @@
         }());
         slider.ensureAnimationEnd = '';
         // CONTROLSCONTAINER:
-        if (slider.vars.controlsContainer !== "") slider.controlsContainer = $(slider.vars.controlsContainer).length > 0 && $(slider.vars.controlsContainer);
+        var controlsContainerSelector = (typeof slider.vars.controlsContainer === "string") ? $.trim(slider.vars.controlsContainer) : "";
+        if (controlsContainerSelector !== "" && controlsContainerSelector.charAt(0) !== "<") {
+          slider.controlsContainer = $(controlsContainerSelector).length > 0 && $(controlsContainerSelector);
+        }
         // MANUAL:
-        if (slider.vars.manualControls !== "") slider.manualControls = $(slider.vars.manualControls).length > 0 && $(slider.vars.manualControls);
+        var manualControlsSelector = (typeof slider.vars.manualControls === "string") ? $.trim(slider.vars.manualControls) : "";
+        if (manualControlsSelector !== "" && manualControlsSelector.charAt(0) !== "<") {
+          slider.manualControls = $(manualControlsSelector).length > 0 && $(manualControlsSelector);
+        }
 
         // RANDOMIZE:
         if (slider.vars.randomize) {


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/15](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/15)

To fix this safely without changing intended functionality, enforce selector-only handling at the point of use in `$.flexslider` for `manualControls` (and similarly `controlsContainer` for consistency), instead of directly passing option strings to `$()`.

Best approach in this snippet:
- In `init`, before using `slider.vars.controlsContainer` / `slider.vars.manualControls`, trim and validate them as selector strings.
- Reject values that look like HTML (`charAt(0) === "<"`), and only then call `$()` and assign if matched elements exist.
- This preserves existing behavior for valid selectors while blocking HTML interpretation in jQuery.

Edit region:
- `assets/flexslider/jquery.flexslider.js`
- Inside `methods.init`, around current lines 81–83.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
