### PR TITLE
Potential fix for code scanning alert no. 21: Unsafe jQuery plugin

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -692,7 +692,9 @@
 
       if (!slider.animating && (slider.canAdvance(target, fromNav) || override) && slider.is(":visible")) {
         if (asNav && withSync) {
-          var master = $(slider.vars.asNavFor).data('flexslider');
+          var masterEl = $.find(slider.vars.asNavFor)[0],
+              master = masterEl ? $(masterEl).data('flexslider') : null;
+          if (!master) { return false; }
           slider.atEnd = target === 0 || target === slider.count - 1;
           master.flexAnimate(target, true, false, true, fromNav);
           slider.direction = (slider.currentItem < target) ? "next" : "prev";


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/21](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/21)

To fix this safely without changing functionality, harden the sink usage so `asNavFor` is interpreted only as a selector, never as HTML. The best minimal change in this file is to replace direct jQuery construction (`$(slider.vars.asNavFor)`) with selector-only lookup via `$.find(...)`, then wrap the result with `$()` for `.data('flexslider')` compatibility.

Concretely in `assets/flexslider/jquery.flexslider.js`, update line region around line 695 inside `slider.flexAnimate`:

- Replace:
  - `var master = $(slider.vars.asNavFor).data('flexslider');`
- With:
  - Build `masterEl` using `$.find(slider.vars.asNavFor)[0]` (selector-only behavior),
  - then conditionally read `flexslider` data if found.

This preserves existing behavior for valid selectors, avoids HTML interpretation, and prevents XSS via crafted `asNavFor`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
