### PR TITLE
Potential fix for code scanning alert no. 11: Unsafe jQuery plugin

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -49,7 +49,7 @@
         slider.atEnd = (slider.currentSlide === 0 || slider.currentSlide === slider.last);
         slider.containerSelector = slider.vars.selector.substr(0,slider.vars.selector.search(' '));
         slider.slides = $(slider.vars.selector, slider);
-        slider.container = $(slider.containerSelector, slider);
+        slider.container = $( $.find(slider.containerSelector, slider) );
         slider.count = slider.slides.length;
         // SYNC:
         slider.syncExists = $.find(slider.vars.sync).length > 0;


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/11](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/11)

Use jQuery’s selector-only lookup (`$.find`) instead of `$()` for the option-derived selector at line 52. This preserves intended behavior (finding container elements by CSS selector within the slider context) while removing HTML interpretation risk from plugin options.

Best single change (no functional redesign):
- In `assets/flexslider/jquery.flexslider.js`, inside `methods.init`, replace:
  - `slider.container = $(slider.containerSelector, slider);`
- With:
  - `slider.container = $( $.find(slider.containerSelector, slider) );`

Why this is best:
- `$.find` interprets input strictly as a selector, not as HTML.
- Wrapping the result in `$()` keeps downstream behavior as a jQuery object unchanged.
- Minimal, localized change; no new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
