### PR TITLE
Potential fix for code scanning alert no. 38: Unsafe jQuery plugin

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -6,10 +6,27 @@
 
   //FlexSlider: Object Instance
   $.flexslider = function(el, options) {
-    var slider = $(el);
+    var slider = $(el),
+        selectorOption,
+        asNavForOption,
+        controlsContainerOption,
+        manualControlsOption;
 
     // making variables public
     slider.vars = $.extend({}, $.flexslider.defaults, options);
+
+    // sanitize selector-like options to avoid HTML interpretation in jQuery calls
+    selectorOption = (typeof slider.vars.selector === "string") ? $.trim(slider.vars.selector) : "";
+    slider.vars.selector = (selectorOption && selectorOption.charAt(0) !== "<") ? selectorOption : ".slides > li";
+
+    asNavForOption = (typeof slider.vars.asNavFor === "string") ? $.trim(slider.vars.asNavFor) : "";
+    slider.vars.asNavFor = (asNavForOption && asNavForOption.charAt(0) !== "<") ? asNavForOption : "";
+
+    controlsContainerOption = (typeof slider.vars.controlsContainer === "string") ? $.trim(slider.vars.controlsContainer) : "";
+    slider.vars.controlsContainer = (controlsContainerOption && controlsContainerOption.charAt(0) !== "<") ? controlsContainerOption : "";
+
+    manualControlsOption = (typeof slider.vars.manualControls === "string") ? $.trim(slider.vars.manualControls) : "";
+    slider.vars.manualControls = (manualControlsOption && manualControlsOption.charAt(0) !== "<") ? manualControlsOption : "";
 
     var namespace = (slider.vars.namespace || "").replace(/[^A-Za-z0-9_-]/g, ""),
         msGesture = window.navigator && window.navigator.msPointerEnabled && window.MSGesture,


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/38](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/38)

The best fix is to harden the constructor path so unsafe selector-like options are sanitized **inside `$.flexslider`** before use, not only in `$.fn.flexslider`.

In `assets/flexslider/jquery.flexslider.js`, immediately after `slider.vars = $.extend({}, $.flexslider.defaults, options);`, normalize and validate selector-bearing fields:
- `selector`: allow only non-empty strings that do not begin with `<`, else fallback to default `".slides > li"`.
- `asNavFor`, `controlsContainer`, `manualControls`: trim string values and set to empty string if they begin with `<` or are invalid.
- Keep behavior unchanged for valid selector strings.

This preserves functionality while ensuring direct constructor usage is safe and removing dependence on callers for sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
