### PR TITLE
Potential fix for code scanning alert no. 38: Unsafe jQuery plugin

### DIFF
--- a/assets/flexslider/jquery.flexslider.js
+++ b/assets/flexslider/jquery.flexslider.js
@@ -65,7 +65,7 @@
         slider.animatingTo = slider.currentSlide;
         slider.atEnd = (slider.currentSlide === 0 || slider.currentSlide === slider.last);
         slider.containerSelector = slider.vars.selector.substr(0,slider.vars.selector.search(' '));
-        slider.slides = $(slider.vars.selector, slider);
+        slider.slides = $( $.find(slider.vars.selector, slider) );
         slider.container = $( $.find(slider.containerSelector, slider) );
         slider.count = slider.slides.length;
         // SYNC:


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/38](https://github.com/lisagorewitdecker/www.lisagorewitdecker.com/security/code-scanning/38)

General fix approach: for plugin options intended to be CSS selectors, do not pass untrusted strings into `$(...)` in a way that could trigger HTML parsing. Prefer selector-only APIs like `$.find(...)` and wrap the result.

Best fix in this file: change the slide lookup at line 68 from:
- `slider.slides = $(slider.vars.selector, slider);`
to:
- `slider.slides = $($.find(slider.vars.selector, slider));`

This preserves behavior (find matching descendants within `slider`) while ensuring the input is treated as a selector, not HTML. Keep existing sanitization in place; this sink-level change is the minimal and strongest improvement without changing plugin functionality.

File/region to edit:
- `assets/flexslider/jquery.flexslider.js`, inside `methods.init` around lines 67–70.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
